### PR TITLE
allow drag-n-drop from toolbar

### DIFF
--- a/src/main/java/com/cburch/draw/canvas/CanvasListener.java
+++ b/src/main/java/com/cburch/draw/canvas/CanvasListener.java
@@ -102,6 +102,7 @@ class CanvasListener implements MouseListener, MouseMotionListener, KeyListener,
 
     @Override
     public void mouseEntered(MouseEvent e) {
+        canvas.requestFocus(); //ask for focus if mouse enteres canvas space
         if (tool != null) {
             tool.mouseEntered(canvas, e);
         }

--- a/src/main/java/com/cburch/draw/toolbar/ToolbarButton.java
+++ b/src/main/java/com/cburch/draw/toolbar/ToolbarButton.java
@@ -80,16 +80,14 @@ class ToolbarButton extends JComponent implements MouseListener {
     @Override
     public void mousePressed(MouseEvent e) {
         if (item != null && item.isSelectable()) {
-            toolbar.setPressed(this);
+            // select item as soon as it's pressed down on
+            // this allows one to drag item from toolbar onto canvas
+            toolbar.getToolbarModel().itemSelected(item); 
         }
     }
 
     @Override
     public void mouseReleased(MouseEvent e) {
-        if (toolbar.getPressed() == this) {
-            toolbar.getToolbarModel().itemSelected(item);
-            toolbar.setPressed(null);
-        }
     }
 
     @Override


### PR DESCRIPTION
This change sets a toolbar item to be selected as soon as mouse down is triggered instead of on release and forces the canvas to take focus when mouse enters its space. This allows dragging items from the toolbar onto the canvas which makes a much nicer experience for using Logisim with a touch screen.